### PR TITLE
Add "Probe" Feature

### DIFF
--- a/ffmpeg-light.cabal
+++ b/ffmpeg-light.cabal
@@ -49,12 +49,15 @@ library
                        Codec.FFmpeg.Encode,
                        Codec.FFmpeg.Enums,
                        Codec.FFmpeg.Juicy,
+                       Codec.FFmpeg.Probe,
                        Codec.FFmpeg.Scaler,
                        Codec.FFmpeg.Types,
                        Codec.FFmpeg.Internal.Debug,
                        Codec.FFmpeg.Internal.Linear
   build-tools:         hsc2hs
   build-depends:       base >=4.6 && < 5,
+                       either,
+                       exceptions,
                        vector >= 0.10.9 && < 0.11,
                        transformers >= 0.4.1 && < 0.5,
                        mtl >= 2.2.1 && < 2.3,

--- a/src/Codec/FFmpeg/Probe.hsc
+++ b/src/Codec/FFmpeg/Probe.hsc
@@ -2,7 +2,10 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Codec.FFmpeg.Probe (
-    withAvFile, nbStreams, formatName
+    withAvFile, nbStreams, formatName,
+
+    -- * Streams
+    AvStreamT, withStream, codecContext
     ) where
 
 import Control.Applicative ( Applicative )
@@ -12,12 +15,17 @@ import Control.Monad.Trans.Either
 import Foreign.C.String ( peekCString )
 import Foreign.C.Types ( CInt )
 import Foreign.Marshal.Utils ( with )
+import Foreign.Ptr ( Ptr, nullPtr )
 import Foreign.Storable
 
 import Codec.FFmpeg.Decode
 import Codec.FFmpeg.Types
 
 #include <libavformat/avformat.h>
+
+-------------------------------------------------------------------------------
+-- avformat - level stuff
+-------------------------------------------------------------------------------
 
 newtype AvFormat m a = AvFormat { unAvFormat :: ReaderT AVFormatContext m a }
     deriving
@@ -37,14 +45,47 @@ withAvFile fn f = do
             (runReaderT (unAvFormat f) ctx)
             (liftIO $ with ctx close_input)
 
-avToInt :: Monad m => AvFormat m CInt -> AvFormat m Int
-avToInt f = f >>= return . fromIntegral
-
 nbStreams :: MonadIO m => AvFormat m Int
 nbStreams = avToInt $ ask >>= \ctx ->
     liftIO $ (#peek AVFormatContext, nb_streams) (getPtr ctx)
 
 formatName :: MonadIO m => AvFormat m String
-formatName = ask >>= \ctx -> do
-    liftIO $ (#peek AVFormatContext, iformat) (getPtr ctx) >>= (#peek AVInputFormat, name) >>= peekCString
-    
+formatName = ask >>= \ctx -> liftIO $
+    (#peek AVFormatContext, iformat) (getPtr ctx) >>=
+    (#peek AVInputFormat, name) >>=
+    peekCString
+
+-------------------------------------------------------------------------------
+-- stream - level stuff
+-------------------------------------------------------------------------------
+
+newtype AvStreamT m a = AvStreamT { unAvStreamT :: ReaderT AVStream (AvFormat m) a }
+    deriving
+        ( Applicative
+        , Functor
+        , Monad
+        , MonadIO
+        , MonadReader AVStream
+        )
+
+withStream :: MonadIO m => Int -> AvStreamT m a -> AvFormat m a
+withStream sid f = nbStreams >>= \ns -> if sid >= ns
+    then error $ show sid ++ " >= " ++ show ns
+    else do
+        ctx <- ask
+        streams <- liftIO $ (#peek AVFormatContext, streams) (getPtr ctx)
+        liftIO (peekElemOff streams sid) >>= runReaderT (unAvStreamT f)
+
+codecContext :: MonadIO m => AvStreamT m (Maybe AVCodecContext)
+codecContext = do
+    p <- ask >>= (\x -> liftIO $ (#peek AVStream, codec) (getPtr x))
+    if (p /= nullPtr)
+        then return $ Just $ AVCodecContext p
+        else return Nothing
+
+-------------------------------------------------------------------------------
+-- helpers
+-------------------------------------------------------------------------------
+
+avToInt :: Monad m => AvFormat m CInt -> AvFormat m Int
+avToInt f = f >>= return . fromIntegral

--- a/src/Codec/FFmpeg/Probe.hsc
+++ b/src/Codec/FFmpeg/Probe.hsc
@@ -1,0 +1,50 @@
+
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Codec.FFmpeg.Probe (
+    withAvFile, nbStreams, formatName
+    ) where
+
+import Control.Applicative ( Applicative )
+import Control.Monad.Catch
+import Control.Monad.Reader
+import Control.Monad.Trans.Either
+import Foreign.C.String ( peekCString )
+import Foreign.C.Types ( CInt )
+import Foreign.Marshal.Utils ( with )
+import Foreign.Storable
+
+import Codec.FFmpeg.Decode
+import Codec.FFmpeg.Types
+
+#include <libavformat/avformat.h>
+
+newtype AvFormat m a = AvFormat { unAvFormat :: ReaderT AVFormatContext m a }
+    deriving
+        ( Applicative
+        , Functor
+        , Monad
+        , MonadIO
+        , MonadReader AVFormatContext
+        )
+
+withAvFile :: (MonadMask m, MonadIO m) => String -> AvFormat m a -> m a
+withAvFile fn f = do
+    ectx <- runEitherT $ openInput fn
+    case ectx of
+        Left e    -> error e
+        Right ctx -> finally
+            (runReaderT (unAvFormat f) ctx)
+            (liftIO $ with ctx close_input)
+
+avToInt :: Monad m => AvFormat m CInt -> AvFormat m Int
+avToInt f = f >>= return . fromIntegral
+
+nbStreams :: MonadIO m => AvFormat m Int
+nbStreams = avToInt $ ask >>= \ctx ->
+    liftIO $ (#peek AVFormatContext, nb_streams) (getPtr ctx)
+
+formatName :: MonadIO m => AvFormat m String
+formatName = ask >>= \ctx -> do
+    liftIO $ (#peek AVFormatContext, iformat) (getPtr ctx) >>= (#peek AVInputFormat, name) >>= peekCString
+    


### PR DESCRIPTION
I'd like to show what I currently have of the "probe" feature I've been talking about. I don't think this is already good for merging, but I'd like to get some early input what you think about it.

To get an idea how it fits together, please have a look at my [mdb](https://github.com/waldheinz/mdb/blob/master/src/Mdb/File.hs#L87) repo, where I'm playing around with it.

The good news is that it seems to be stable, I've been using it to probe through throusands of media files of widely varying formats with no problems.

The bad news is that it's not really following the style of the rest of your library: I'm offering monad transformers for working with `AVFormatContext` and `AVStream`, and a few functions to get from one to the other.

The upside of this approach is that it allows to make the API safe to use from the Haskell side (for example `codecContext` does the null pointer check and returns a `Maybe`, so the user can't dereference a null pointer). The obvious downside is that this is probably not as lightweight as you'd like the library to be.

BTW: Working with ffmpeg was much smoother than I initially expected, so I'm planning on using it for live transcoding of videos as well. This way there could be a HTML5 video player embedded in my `mdb` project, which would be a nice addition. I'm not sure if `ffmpeg-light` is already up to the task, so I'll probably do some more additions soon.