### PR TITLE
Add a configuration field to the camera (API change!)

### DIFF
--- a/demo/Main.hs
+++ b/demo/Main.hs
@@ -67,7 +67,7 @@ loopFor time m =
 testCamera :: IO ()
 testCamera =
   do initFFmpeg
-     (getFrame, cleanup) <- imageReader (Camera "0:0")
+     (getFrame, cleanup) <- imageReader (Camera "0:0" defaultCameraConfig)
      frame1 <- getFrame
      case frame1 of
        img@(Just (Image w h _)) ->

--- a/src/Codec/FFmpeg/Types.hsc
+++ b/src/Codec/FFmpeg/Types.hsc
@@ -216,7 +216,16 @@ instance Storable AVFrac where
                                (#poke AVFrac, den) ptr d
 
 -- | The input source can be a file or a camera.  When using 'Camera',
--- frequently in the form @Camera "0:0"@, the first input video device
+-- frequently in the form @Camera "0:0" defaultCameraConfig@, the first input video device
 -- enumerated by libavdevice is selected.
-data InputSource = File FilePath | Camera String
+data InputSource = File FilePath | Camera String CameraConfig
             deriving (Eq, Ord, Show, Read)
+
+data CameraConfig =
+  CameraConfig { framerate  :: Maybe Int
+               , resolution :: Maybe (Int,Int)
+               }
+          deriving (Eq,Ord,Show,Read)
+
+defaultCameraConfig :: CameraConfig
+defaultCameraConfig = CameraConfig (Just 30) Nothing


### PR DESCRIPTION
I was noticing ffmpeg was suddenly selecting the lowest resolution by default
where it was previously selecting something decent. Now users can use
'defaultCameraConfig' or specify the resolution and framerate of their choice.