### PR TITLE
Use av_strerror for FFmpeg error messages

### DIFF
--- a/src/Codec/FFmpeg/Decode.hs
+++ b/src/Codec/FFmpeg/Decode.hs
@@ -106,7 +106,8 @@ openFile filename =
     withCString filename $ \cstr ->
       do poke (castPtr ctx) nullPtr
          r <- avformat_open_input ctx cstr nullPtr nullPtr
-         when (r /= 0) (fail $ "ffmpeg failed opening file: " ++ show r)
+         when (r /= 0) (stringError r >>= \s ->
+                          fail $ "ffmpeg failed opening file: " ++ s)
          peek ctx
 
 -- | @AVFrame@ is a superset of @AVPicture@, so we can upcast an

--- a/src/Codec/FFmpeg/Decode.hs
+++ b/src/Codec/FFmpeg/Decode.hs
@@ -60,8 +60,9 @@ dictSet :: Ptr AVDictionary -> String -> String -> IO ()
 dictSet d k v = do
   r <- withCString k $ \k' -> withCString v $ \v' ->
          av_dict_set d k' v' 0
-  when (r < 0)
-       (error $ "av_dict_set failed("++show r++"): "++k++" => "++v)
+  when (r < 0) $
+    stringError r >>= \err ->
+       error $ "av_dict_set failed("++ err ++"): "++k++" => "++v
 
 -- * FFmpeg Decoding Interface
 
@@ -76,7 +77,9 @@ openCamera cam cfg =
          r <- alloca $ \dict -> do
                 setConfig dict cfg
                 avformat_open_input ctx cstr nullPtr dict
-         when (r /= 0) (fail $ "ffmpeg failed opening file: " ++ show r)
+         when (r /= 0) $
+           stringError r >>= \err ->
+             fail ("ffmpeg failed opening file: " ++ err)
          peek ctx
   where
     run :: (a -> IO b) -> Maybe a -> IO ()


### PR DESCRIPTION
This should resolve #42. I've used the new `stringError` function for `openFile`, and for two other cases I found that seemed to make sense. There might be other places in other modules. Do you think I should go through those, or can that be done later (as someone works with those modules?) I couldn't find any other `show r`-like cases.

I didn't find any test suites to extend or run, but I've verified in my own project that the error message appears correctly (managed to trigger two different messages). The demos also seems to work as before.

Happy for any feedback!