### PR TITLE
VPlay: honour the pixel aspect ratio

### DIFF
--- a/demo/VPlay.hs
+++ b/demo/VPlay.hs
@@ -266,13 +266,28 @@ videoPlayer cfg src = do
       (vsIdx, ctx, _, vs, _) <- prepareVideoCodec inputContext
 
       -- Get frame size.
-      w <- liftIO $ getWidth ctx
-      h <- liftIO $ getHeight ctx
+      textureWidth <- liftIO $ getWidth ctx
+      textureHeight <- liftIO $ getHeight ctx
+
+      -- Compute window size. If the pixels aren't square, stretch the window,
+      -- SDL will automatically scale the texture to fit.
+      par <- liftIO $ getAspectRatio ctx
+
+      let rawAspectRatio :: Double
+          rawAspectRatio = fromIntegral (numerator par) / fromIntegral (denomenator par)
+
+          -- 0 means "unknown", so we default to 1, meaning "square pixels"
+          aspectRatio :: Double
+          aspectRatio = if rawAspectRatio == 0 then 1 else rawAspectRatio
+
+          windowWidth, windowHeight :: CInt
+          windowWidth = round (aspectRatio * fromIntegral textureWidth)
+          windowHeight = textureHeight
 
       -- Create window, renderer and texture.
-      window   <- createWindow w h
+      window   <- createWindow windowWidth windowHeight
       renderer <- createRenderer window
-      texture  <- createTexture renderer w h
+      texture  <- createTexture renderer textureWidth textureHeight
 
       -- Create frame reader.
       let dstFmt = cfgFmtFFmpeg cfg

--- a/demo/VPlay.hs
+++ b/demo/VPlay.hs
@@ -271,17 +271,13 @@ videoPlayer cfg src = do
 
       -- Compute window size. If the pixels aren't square, stretch the window,
       -- SDL will automatically scale the texture to fit.
-      par <- liftIO $ getAspectRatio ctx
+      par <- liftIO $ guessAspectRatio ctx
 
-      let rawAspectRatio :: Double
-          rawAspectRatio = fromIntegral (numerator par) / fromIntegral (denomenator par)
-
-          -- 0 means "unknown", so we default to 1, meaning "square pixels"
-          aspectRatio :: Double
-          aspectRatio = if rawAspectRatio == 0 then 1 else rawAspectRatio
+      let pixelAspectRatio :: Double
+          pixelAspectRatio = fromIntegral (numerator par) / fromIntegral (denomenator par)
 
           windowWidth, windowHeight :: CInt
-          windowWidth = round (aspectRatio * fromIntegral textureWidth)
+          windowWidth = round (pixelAspectRatio * fromIntegral textureWidth)
           windowHeight = textureHeight
 
       -- Create window, renderer and texture.

--- a/src/Codec/FFmpeg/Types.hsc
+++ b/src/Codec/FFmpeg/Types.hsc
@@ -77,6 +77,7 @@ newtype AVCodecContext = AVCodecContext (Ptr ()) deriving (Storable, HasPtr)
 #mkField CodecFlags, CodecFlag
 #mkField CodecID, AVCodecID
 #mkField PrivData, (Ptr ())
+#mkField AspectRatio, AVRational
 
 #hasField AVCodecContext, Width, width
 #hasField AVCodecContext, Height, height
@@ -86,6 +87,7 @@ newtype AVCodecContext = AVCodecContext (Ptr ()) deriving (Storable, HasPtr)
 #hasField AVCodecContext, CodecFlags, flags
 #hasField AVCodecContext, CodecID, codec_id
 #hasField AVCodecContext, PrivData, priv_data
+#hasField AVCodecContext, AspectRatio, sample_aspect_ratio
 
 newtype AVStream = AVStream (Ptr ()) deriving (Storable, HasPtr)
 


### PR DESCRIPTION
Some video cameras produce video files with non-square pixels, so when playing on a screen with square pixels, video players need to compensate by stretching the image.