### PR TITLE
expose ticks_per_frame

### DIFF
--- a/src/Codec/FFmpeg/Types.hsc
+++ b/src/Codec/FFmpeg/Types.hsc
@@ -77,6 +77,7 @@ newtype AVCodecContext = AVCodecContext (Ptr ()) deriving (Storable, HasPtr)
 #mkField CodecFlags, CodecFlag
 #mkField CodecID, AVCodecID
 #mkField PrivData, (Ptr ())
+#mkField TicksPerFrame, CInt
 
 #hasField AVCodecContext, Width, width
 #hasField AVCodecContext, Height, height
@@ -86,6 +87,13 @@ newtype AVCodecContext = AVCodecContext (Ptr ()) deriving (Storable, HasPtr)
 #hasField AVCodecContext, CodecFlags, flags
 #hasField AVCodecContext, CodecID, codec_id
 #hasField AVCodecContext, PrivData, priv_data
+#hasField AVCodecContext, TicksPerFrame, ticks_per_frame
+
+getFps :: (HasTimeBase a, HasTicksPerFrame a) => a -> IO CDouble
+getFps x = do
+  timeBase <- getTimeBase x
+  ticksPerFrame <- getTicksPerFrame x
+  pure (1.0 / av_q2d timeBase / fromIntegral ticksPerFrame)
 
 newtype AVStream = AVStream (Ptr ()) deriving (Storable, HasPtr)
 


### PR DESCRIPTION
`time_base` is not sufficient to compute the fps, see [the implementation of `get_fps` in ffmpeg](https://www.ffmpeg.org/doxygen/3.1/ratecontrol_8c_source.html#l00063):

    static double get_fps(AVCodecContext *avctx)
    {
        return 1.0 / av_q2d(avctx->time_base) / FFMAX(avctx->ticks_per_frame, 1);
    }

This doesn't affect `VPlay` because it uses the timestamps of the individual frames. However, it does affect applications which decode, modify, and then re-encode videos, because the encoding API requires the fps, and with some formats the reciprocal of `getTimeBase` is not equal to the fps, but equal to 2 times the fps. `Transcode` is not affected either because it does not attempt to preserve the fps of the original video.