### PR TITLE
Support GHC-8.8.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,20 @@ before_cache:
   - rm -rfv $CABALHOME/packages/head.hackage
 matrix:
   include:
+    - compiler: ghc-8.8.1
+      addons:
+        apt:
+          sources:
+            - hvr-ghc
+          packages:
+            - ghc-8.8.1
+            - cabal-install-3.0
+            - ffmpeg
+            - libavutil-dev
+            - libavformat-dev
+            - libavcodec-dev
+            - libswscale-dev
+            - libavdevice-dev
     - compiler: ghc-8.4.2
       addons:
         apt:

--- a/ffmpeg-light.cabal
+++ b/ffmpeg-light.cabal
@@ -15,7 +15,7 @@ description:         Stream frames from an encoded video, or stream frames to
                      > go = do (getFrame, cleanup) <- imageReader "myVideo.mov"
                      >         (fmap ImageRGB8 <$> getFrame) <* cleanup
                      .
-                     Tested with FFmpeg 3.1 - 3.4.2
+                     Tested with FFmpeg 3.1 - 3.4.6
 
 license:             BSD3
 license-file:        LICENSE
@@ -28,7 +28,7 @@ category:            Codec
 build-type:          Simple
 extra-source-files:  src/hscMacros.h, src/nameCompat.h, CHANGELOG.md
 cabal-version:       >=1.10
-tested-with:         GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.2
+tested-with:         GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.2, GHC == 8.8.1
 
 source-repository head
   type:     git

--- a/src/Codec/FFmpeg/Decode.hs
+++ b/src/Codec/FFmpeg/Decode.hs
@@ -9,8 +9,8 @@ import Codec.FFmpeg.Scaler
 import Codec.FFmpeg.Types
 import Control.Arrow (first)
 import Control.Monad (when, void)
-import Control.Monad.Except
-import Control.Monad.Trans.Maybe
+import Control.Monad.Except (MonadIO, MonadError, liftIO, throwError, catchError)
+import Control.Monad.Trans.Maybe (MaybeT(MaybeT))
 import Foreign.C.String
 import Foreign.C.Types
 import Foreign.Marshal.Alloc (alloca, free, mallocBytes)

--- a/src/Codec/FFmpeg/Juicy.hs
+++ b/src/Codec/FFmpeg/Juicy.hs
@@ -10,14 +10,13 @@ import Codec.FFmpeg.Internal.Linear (V2(..))
 import Codec.FFmpeg.Types
 import Control.Arrow (first)
 import Control.Monad ((>=>))
-import Control.Monad.Except
-import Control.Monad.Trans.Maybe
+import Control.Monad.Except (MonadIO, MonadError, lift, guard, runExceptT)
+import Control.Monad.Trans.Maybe (MaybeT(MaybeT), runMaybeT)
 import Data.Foldable (traverse_)
 import qualified Data.Vector.Storable as V
 import qualified Data.Vector.Storable.Mutable as VM
-import Foreign.C.Types
+import Foreign.C.Types (CUChar)
 import Foreign.Storable (sizeOf)
-import Data.Maybe (maybe)
 
 
 -- | Convert 'AVFrame' to a 'Vector'.

--- a/src/Codec/FFmpeg/Probe.hsc
+++ b/src/Codec/FFmpeg/Probe.hsc
@@ -16,16 +16,16 @@ module Codec.FFmpeg.Probe (
     dictFoldM_
     ) where
 
-import Control.Applicative ( Applicative )
 import Control.Monad.Catch ( MonadMask, finally )
-import Control.Monad.Reader
-import Control.Monad.Trans.Except
+import Control.Monad.Reader ( MonadIO, ReaderT, MonadReader, MonadTrans, liftM
+                            , liftIO, ask, runReaderT )
+import Control.Monad.Trans.Except ( runExceptT )
 import Data.Int ( Int64 )
 import Foreign.C.String ( CString, peekCString, withCString )
 import Foreign.C.Types ( CInt(..) )
 import Foreign.Marshal.Utils ( with )
 import Foreign.Ptr ( Ptr, nullPtr )
-import Foreign.Storable
+import Foreign.Storable ( peekByteOff, peekElemOff )
 
 import Codec.FFmpeg.Enums
 import Codec.FFmpeg.Decode

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2016-06-21
+resolver: nightly-2019-10-06
 
 packages:
 - '.'
@@ -6,9 +6,8 @@ packages:
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
 extra-deps:
-- Rasterific-0.6.1.1
-- FontyFruity-0.5.3.2
-- sdl2-2.1.3
+- FontyFruity-0.5.3.5@sha256:d0bbbc5bef14f229c8e90271365916b1b470bc0928ff4670f7d1885aec3378cf,2166
+- Rasterific-0.7.4.4@sha256:05ca492a2c95e65da8d120281f5e579321cfe47b586a5730dce54ae1c52d1557,6008
 
 # Override default flag values for local packages and extra-deps
 flags:


### PR DESCRIPTION
- Add GHC-8.8.1 to the Travis build matrix and `tested-with` in the Cabal file.
- Bump to a nightly LTS version using GHC-8.8.1 in preparation for a stable LTS release for GHC-8.8.1.
- Use explicit imports in a few places to avoid warnings about unnecessary imports.
- Update the versions of ffmpeg that the library has been tested with.