### PR TITLE
Introduce new Bytes InputSource

### DIFF
--- a/src/Codec/FFmpeg/Enums.hsc
+++ b/src/Codec/FFmpeg/Enums.hsc
@@ -513,6 +513,11 @@ newtype LogLevel = LogLevel CInt deriving (Eq, Bits, Storable)
  , AV_LOG_TRACE\
  , AV_LOG_MAX_OFFSET
 
+newtype AVError = AVError CInt deriving (Eq, Bits, Storable)
+#enum AVError, AVError \
+ , AVERROR_EOF \
+ , AVERROR_EXIT
+
 newtype AVSampleFormat = AVSampleFormat CInt deriving (Eq, Bits, Storable)
 #enum AVSampleFormat, AVSampleFormat \
  , AV_SAMPLE_FMT_NONE\

--- a/src/Codec/FFmpeg/Types.hsc
+++ b/src/Codec/FFmpeg/Types.hsc
@@ -9,6 +9,7 @@ import Foreign.C.Types
 import Foreign.Ptr
 import Foreign.Storable
 import Foreign.Marshal.Alloc (malloc)
+import qualified Data.ByteString.Lazy as Lazy
 
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
@@ -44,7 +45,6 @@ setFilename ctx fn =
            dst   = (#ptr AVFormatContext, filename) ptr
            bytes = map (fromIntegral . fromEnum) fn
        zipWithM_ (pokeElemOff dst) bytes [(0 :: CInt) ..]
-
 
 foreign import ccall "av_input_video_device_next"
   av_input_video_device_next :: AVInputFormat -> IO AVInputFormat
@@ -360,7 +360,7 @@ instance Storable AVFrac where
 -- | The input source can be a file or a camera.  When using 'Camera',
 -- frequently in the form @Camera "0:0" defaultCameraConfig@, the first input video device
 -- enumerated by libavdevice is selected.
-data InputSource = File FilePath | Camera String CameraConfig
+data InputSource = File FilePath | Camera String CameraConfig | Bytes Lazy.ByteString
             deriving (Eq, Ord, Show, Read)
 
 data CameraConfig =


### PR DESCRIPTION
Lazy ByteString deliver works. Cleanup still missing

This is working, but incomplete. I would appreciate some feedback on the direction, especially how to handle cleanup. I'm thinking of changing the API of `openInput` by also returning a `cleanupInput` action and combining with the existing cleanup in `frame*Reader` functions.

Also, any other feedback on what would make this mergeable would be nice.

Issue #54
(I added this on top of the audio branch, as I presumed this would be the most likely point of merge in the future, let me know if I should bring it over to master instead)
